### PR TITLE
Remove version tag from nightly

### DIFF
--- a/.github/workflows/deploy-nightly.yml
+++ b/.github/workflows/deploy-nightly.yml
@@ -35,4 +35,4 @@ jobs:
       with:
         push: true
         platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8
-        tags: peterlewis/wg-easy:nightly, peterlewis/wg-easy:${{ env.RELEASE }}-nightly
+        tags: peterlewis/wg-easy:nightly


### PR DESCRIPTION
Serves no real purpose as nightly is nightly, and can be between versions.